### PR TITLE
Make benchmark peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   "devDependencies": {
     "benchmark": "2.1.3",
     "browserify": "14.1.0",
-    "karma": "^1.5.0",
+    "browserify-shim": "^3.8.13",
     "jasmine": "2.5.3",
     "jasmine-expect": "3.6.0",
+    "karma": "^1.5.0",
     "xo": "0.17.1"
   },
   "files": [
@@ -49,6 +50,12 @@
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json"
+  },
+  "browserify": {
+    "transform": [ "browserify-shim" ]
+  },
+  "browserify-shim": {
+    "benchmark": "global:Benchmark"
   },
   "xo": {
     "envs": [

--- a/package.json
+++ b/package.json
@@ -9,13 +9,17 @@
     "Larry Davis <lazdnet@gmail.com>"
   ],
   "dependencies": {
-    "benchmark": "2.1.3",
-    "karma": "1.5.0",
     "lodash": "4.17.4",
     "platform": "1.3.3"
   },
+  "peerDependencies": {
+    "benchmark": "^2.1.0",
+    "karma": "^1.5.0"
+  },
   "devDependencies": {
+    "benchmark": "2.1.3",
     "browserify": "14.1.0",
+    "karma": "^1.5.0",
     "jasmine": "2.5.3",
     "jasmine-expect": "3.6.0",
     "xo": "0.17.1"


### PR DESCRIPTION
Make benchmark.js a peer dependency that a project might use a different version.
E.g. a version that points to a pull request.